### PR TITLE
Only show the panel scrollbar when needed

### DIFF
--- a/pwa/style.css
+++ b/pwa/style.css
@@ -72,7 +72,9 @@ article {
   margin: var(--gutter);
   white-space: normal;
   overflow-x: hidden;
-  overflow-y: scroll;
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+  scrollbar-width: thin;
 }
 
 /* page typeface, color, and white space */

--- a/pwa/wiki.js
+++ b/pwa/wiki.js
@@ -391,6 +391,7 @@ function panelAdapter({id, host, flag, page: {title, story=[], journal=[]}}) {
           <footer></footer>
           </article>`
       })
+    console.log('panelAdapter', { id, main })
     // TODO for(let edit of journal) {/*...*/}
   }
 }

--- a/pwa/wiki.js
+++ b/pwa/wiki.js
@@ -131,7 +131,7 @@ window.addEventListener("load", async () => {
         deps: ['html'],
         fn: (item, html) => {
           const div = document.createElement('div')
-          div.classList.add('item', 'unknown')
+          div.classList.add('item', 'unknown', item.id)
           const inspector = new Inspector(div)
           inspector.fulfilled(item)
           div.prepend(html`<p><em>Unknown type:</em> ${item.type}`)
@@ -181,17 +181,17 @@ window.addEventListener("load", async () => {
       {
         type: 'paragraph',
         deps: ['html', 'linked', 'annotateLinks'],
-        fn: (item, html, linked, annotateLinks) => annotateLinks(html`<p>${linked(item.text)}`)
+        fn: (item, html, linked, annotateLinks) => annotateLinks(html`<div class='item ${item.id}'><p>${linked(item.text)}`)
       },
       {
         type: 'html',
         deps: ['html', 'linked', 'annotateLinks'],
-        fn: (item, html, linked, annotateLinks) => annotateLinks(html`${linked(item.text)}`)
+        fn: (item, html, linked, annotateLinks) => annotateLinks(html`<div class='item ${item.id}'>${linked(item.text)}`)
       },
       {
         type: 'markdown',
         deps: ['md', 'linked', 'annotateLinks'],
-        fn: (item, md, linked, annotateLinks) => annotateLinks(md`${linked(item.text)}`)
+        fn: (item, md, linked, annotateLinks) => annotateLinks(md`<div class='item ${item.id}'>${linked(item.text)}`)
       },
       {
         type: 'reference',
@@ -201,7 +201,7 @@ window.addEventListener("load", async () => {
           const flag = `//${site}/favicon.png`
           // how links within a reference are annotated needs some thought!
           const p = annotateLinks(html`
-          <p><img class="remote" src="${flag}">
+          <div class='item ${item.id}'><p><img class="remote" src="${flag}">
             <a class="internal" data-title="${title}"
                href="//${site}/${slug}.html">${title}</a> - ${linked(text)}`)
           // remove the onclick from annotateLinks() before adding our own click handler.
@@ -219,7 +219,7 @@ window.addEventListener("load", async () => {
       {
         type: 'pagefold',
         deps: ['html'],
-        fn: (item, html) => html`<hr class="pagefold" data-content="${item.text}">`
+        fn: (item, html) => html`<div class='item ${item.id}'><hr class="pagefold" data-content="${item.text}">`
       }
     ],
     addPanel(panel, article, keepLineup=false) {

--- a/pwa/wiki.js
+++ b/pwa/wiki.js
@@ -85,6 +85,7 @@ window.addEventListener("load", async () => {
               const panel = event.target.closest('article')
               const panelId = panel.id.substr(5)
               // retrieve the page from the lineup
+              // TODO: Do we do it this way, or use Observable variables
               const currentPanel = wiki.lineup.find((element) => element.id == panelId)
               // search of page title within the current page's context
               // TODO: does this item have any item specific context?
@@ -222,6 +223,7 @@ window.addEventListener("load", async () => {
       }
     ],
     addPanel(panel, article, keepLineup=false) {
+      // TODO: If removing panels we need to also remove the associated Observable variables.
       if (!!keepLineup == false) {
         const mainEl = document.querySelector('main')
         while (mainEl.lastChild && mainEl.lastChild.firstChild != article) {
@@ -304,6 +306,10 @@ window.addEventListener("load", async () => {
           main.variable().define('panelId', `panel${id}`)
 
           // TODO for(let edit of journal) {/*...*/}
+
+          // QUESTION: Do we save the context as a variable, 
+          //      rather than as part of a panel in wiki.lineup ?
+
           main.variable(observer('panel')).define(
             'panel',
             ['html', 'width', 'title', 'flag', 'panelId', 'preview'],
@@ -465,6 +471,8 @@ async function panel(domain, { title, slug }) {
       return res.json()
     })
     .then((page) => {
+      // QUESTION: This does not seem like the right place to store the context! 
+      //    Use Observable variable instead?
       return {
         id: randomId(),
         host: domain,
@@ -482,6 +490,7 @@ async function panel(domain, { title, slug }) {
 }
 
 function extractContext(host, page) {
+  // QUESTION: Do we do context like this, or use Observable variables?
   // A page's context has two parts,
   // * the pages fork history
   // * individual item history created by being included from elswwhere

--- a/pwa/wiki.js
+++ b/pwa/wiki.js
@@ -89,7 +89,7 @@ window.addEventListener("load", async () => {
               // search of page title within the current page's context
               // TODO: does this item have any item specific context?
               //         is it a reference or item with attribution?
-              // QUESTION: How to get the item id, so we can search of item context
+              // QUESTION: How to get the item id, so we can add item context
               const { site, slug } = await wiki.findpage({ title, context: currentPanel.context.page })
               // add panel to the lineup
               // - 


### PR DESCRIPTION
Only show vertical scrollbar if it is needed `overflow-y: auto;`,
but reserve space for it `scrollbar-gutter: stable;`,
and make it thin `scrollbar-width: thin;`

Screenshot showing the current spike, proposed change, and the current client. When required the scrollbar will be the same width as in the current client.
<img width="1497" alt="Screenshot 2023-09-21 at 12 02 20" src="https://github.com/dobbs/wiki-spike-css/assets/1552489/2db246c5-0cf8-421b-9b9d-e0a12ef8bd5b">
